### PR TITLE
Use require function to inspect availability of pROC package

### DIFF
--- a/web-app/Rscripts/LogisticRegression/LogisticRegressionLoader.R
+++ b/web-app/Rscripts/LogisticRegression/LogisticRegressionLoader.R
@@ -22,8 +22,7 @@ LogisticRegressionData.loader <- function(
 	library(ggplot2)
 	library(Cairo)
 	library(visreg)
-	pROC.available <- "pROC" %in% row.names(installed.packages())
-	if (pROC.available) library(pROC)
+	pROC.available <- require("pROC")
 	######################################################
 	
 	######################################################


### PR DESCRIPTION
@forus TraIT's JIRA issue (https://jira.ctmmtrait.nl/browse/FT-1757) is addressed with this pull request.
The way LogisticRegressionLoader.R checked the availability of the "pROC" package appears not to be very robust (the used function "installed.packages()" might not properly work depending on the Rserve configuration). According to the documentation, using "require()" is more robust.

The error, I encountered on test-1dot2, was due to the failure of retrieving installed packages information. I'm not sure if this server has the "pROC" library installed, but the deployment of tranSMART at Vancis should include the installation of all required R packages on Rserve. But that list of required R packages is part of transmart-data (R/cran_pkg.R), so that should work.